### PR TITLE
Add check for MapView child truthy value

### DIFF
--- a/packages/react-native-component-map-clustering/MapView.js
+++ b/packages/react-native-component-map-clustering/MapView.js
@@ -52,19 +52,21 @@ class MapView extends PureComponent {
     const GeoJSONs = [];
     const others = [];
     React.Children.forEach(this.props.children, child => {
-      if (child.props && child.props.coordinate) {
-        GeoJSONs.push({
-          properties: {
-            id: child.props.id,
-          },
-          Marker: child,
-          geometry: {
-            type: 'Point',
-            coordinates: [child.props.coordinate.longitude, child.props.coordinate.latitude],
-          },
-        });
-      } else {
-        others.push(child);
+      if (child) {
+        if (child.props && child.props.coordinate) {
+          GeoJSONs.push({
+            properties: {
+              id: child.props.id,
+            },
+            Marker: child,
+            geometry: {
+              type: 'Point',
+              coordinates: [child.props.coordinate.longitude, child.props.coordinate.latitude],
+            },
+          });
+        } else {
+          others.push(child);
+        }
       }
     });
     this.setState(


### PR DESCRIPTION
Conditionally rendered markers are throwing a type error when condition is falsey:
`TypeError: Cannot read property 'props' of null`

```
<MapView
  ...
>
  <Marker ... />
  <Marker ... />
  {false && <Marker ... />}
</MapView>
```
`this.props.children // [{...}, {...}, null]`

I wrapped the whole if/else as opposed to doing `if (child && child.props...`, to avoid pushing `null` values to the `others` array.